### PR TITLE
feat: registry types and YAML parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,4 +22,5 @@ require (
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sys v0.30.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -38,3 +38,5 @@ golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,0 +1,42 @@
+package registry
+
+import (
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ParseRegistry deserializes YAML bytes into a RegistryFile.
+func ParseRegistry(data []byte) (*RegistryFile, error) {
+	var reg RegistryFile
+	if err := yaml.Unmarshal(data, &reg); err != nil {
+		return nil, err
+	}
+	if reg.Clusters == nil {
+		reg.Clusters = make(map[string][]ClaimEntry)
+	}
+	return &reg, nil
+}
+
+// UpdateClaimStatus finds a claim by cluster and claimRef, then updates its
+// StatusMessage and LastCheckedAt. Returns true if a matching entry was found.
+func UpdateClaimStatus(reg *RegistryFile, cluster, claimRef, status string) bool {
+	claims, ok := reg.Clusters[cluster]
+	if !ok {
+		return false
+	}
+	for i := range claims {
+		if claims[i].ClaimRef == claimRef {
+			claims[i].StatusMessage = status
+			claims[i].LastCheckedAt = time.Now().UTC().Format(time.RFC3339)
+			reg.Clusters[cluster] = claims
+			return true
+		}
+	}
+	return false
+}
+
+// SerializeRegistry marshals a RegistryFile back to YAML bytes.
+func SerializeRegistry(reg *RegistryFile) ([]byte, error) {
+	return yaml.Marshal(reg)
+}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,0 +1,127 @@
+package registry
+
+import (
+	"testing"
+)
+
+const sampleYAML = `cluster-01:
+  - name: my-db
+    namespace: default
+    claimRef: postgresqls.2.2.2/my-db
+    statusMessage: Ready
+    lastCheckedAt: "2026-01-01T00:00:00Z"
+  - name: my-cache
+    namespace: default
+    claimRef: redis.3.0.0/my-cache
+    statusMessage: Pending
+    lastCheckedAt: "2026-01-01T00:00:00Z"
+cluster-02:
+  - name: web-db
+    namespace: apps
+    claimRef: postgresqls.2.2.2/web-db
+    statusMessage: Ready
+    lastCheckedAt: "2026-01-01T00:00:00Z"
+`
+
+func TestParseRegistry(t *testing.T) {
+	reg, err := ParseRegistry([]byte(sampleYAML))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(reg.Clusters) != 2 {
+		t.Fatalf("expected 2 clusters, got %d", len(reg.Clusters))
+	}
+	claims := reg.Clusters["cluster-01"]
+	if len(claims) != 2 {
+		t.Fatalf("expected 2 claims in cluster-01, got %d", len(claims))
+	}
+	if claims[0].ClaimRef != "postgresqls.2.2.2/my-db" {
+		t.Errorf("unexpected claimRef: %s", claims[0].ClaimRef)
+	}
+}
+
+func TestUpdateClaimStatus_Existing(t *testing.T) {
+	reg, err := ParseRegistry([]byte(sampleYAML))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	changed := UpdateClaimStatus(reg, "cluster-01", "postgresqls.2.2.2/my-db", "Degraded")
+	if !changed {
+		t.Fatal("expected UpdateClaimStatus to return true")
+	}
+
+	claim := reg.Clusters["cluster-01"][0]
+	if claim.StatusMessage != "Degraded" {
+		t.Errorf("expected StatusMessage 'Degraded', got %q", claim.StatusMessage)
+	}
+	if claim.LastCheckedAt == "2026-01-01T00:00:00Z" {
+		t.Error("expected LastCheckedAt to be updated")
+	}
+}
+
+func TestUpdateClaimStatus_NonExistent(t *testing.T) {
+	reg, err := ParseRegistry([]byte(sampleYAML))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	changed := UpdateClaimStatus(reg, "cluster-01", "nonexistent/claim", "Degraded")
+	if changed {
+		t.Fatal("expected UpdateClaimStatus to return false for non-existent claim")
+	}
+
+	changed = UpdateClaimStatus(reg, "no-such-cluster", "postgresqls.2.2.2/my-db", "Degraded")
+	if changed {
+		t.Fatal("expected UpdateClaimStatus to return false for non-existent cluster")
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	reg1, err := ParseRegistry([]byte(sampleYAML))
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	data, err := SerializeRegistry(reg1)
+	if err != nil {
+		t.Fatalf("serialize error: %v", err)
+	}
+
+	reg2, err := ParseRegistry(data)
+	if err != nil {
+		t.Fatalf("re-parse error: %v", err)
+	}
+
+	if len(reg2.Clusters) != len(reg1.Clusters) {
+		t.Fatalf("cluster count mismatch: %d vs %d", len(reg1.Clusters), len(reg2.Clusters))
+	}
+
+	for cluster, claims1 := range reg1.Clusters {
+		claims2, ok := reg2.Clusters[cluster]
+		if !ok {
+			t.Fatalf("cluster %q missing after round-trip", cluster)
+		}
+		if len(claims1) != len(claims2) {
+			t.Fatalf("claim count mismatch for %q: %d vs %d", cluster, len(claims1), len(claims2))
+		}
+		for i := range claims1 {
+			if claims1[i] != claims2[i] {
+				t.Errorf("claim mismatch at %s[%d]: %+v vs %+v", cluster, i, claims1[i], claims2[i])
+			}
+		}
+	}
+}
+
+func TestParseRegistry_Empty(t *testing.T) {
+	reg, err := ParseRegistry([]byte(""))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if reg.Clusters == nil {
+		t.Fatal("expected non-nil Clusters map")
+	}
+	if len(reg.Clusters) != 0 {
+		t.Fatalf("expected 0 clusters, got %d", len(reg.Clusters))
+	}
+}

--- a/internal/registry/types.go
+++ b/internal/registry/types.go
@@ -1,0 +1,25 @@
+package registry
+
+import "gopkg.in/yaml.v3"
+
+// ClaimEntry represents a single crossplane claim tracked in the registry.
+type ClaimEntry struct {
+	Name          string `yaml:"name"`
+	Namespace     string `yaml:"namespace"`
+	ClaimRef      string `yaml:"claimRef"`
+	StatusMessage string `yaml:"statusMessage"`
+	LastCheckedAt string `yaml:"lastCheckedAt"`
+}
+
+// RegistryFile holds the full registry: a mapping of cluster names to their claim entries.
+type RegistryFile struct {
+	Clusters map[string][]ClaimEntry
+}
+
+func (r *RegistryFile) UnmarshalYAML(value *yaml.Node) error {
+	return value.Decode(&r.Clusters)
+}
+
+func (r RegistryFile) MarshalYAML() (any, error) {
+	return r.Clusters, nil
+}


### PR DESCRIPTION
## Summary
- Define `ClaimEntry` and `RegistryFile` types with YAML tags and custom marshal/unmarshal in `internal/registry/types.go`
- Implement `ParseRegistry`, `UpdateClaimStatus`, and `SerializeRegistry` functions in `internal/registry/registry.go`
- Add comprehensive tests (parse, update existing/non-existent, round-trip, empty input) in `internal/registry/registry_test.go`

Closes #7

## Test plan
- [x] `go test ./internal/registry/ -v -race` — all 5 tests pass
- [x] `go vet ./...` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)