### PR TITLE
feat: in-memory status store

### DIFF
--- a/internal/collector/store.go
+++ b/internal/collector/store.go
@@ -1,0 +1,79 @@
+package collector
+
+import (
+	"sync"
+	"time"
+)
+
+// StatusEntry represents a status update received from a cluster agent.
+type StatusEntry struct {
+	Cluster       string
+	ClaimRef      string
+	StatusMessage string
+	ReceivedAt    time.Time
+}
+
+// StatusStore is a thread-safe in-memory store for collecting status updates.
+// It tracks dirty state to signal when a reconciliation PR is needed.
+type StatusStore struct {
+	sync.RWMutex
+	entries map[string]StatusEntry
+	dirty   bool
+}
+
+// NewStatusStore creates an empty StatusStore.
+func NewStatusStore() *StatusStore {
+	return &StatusStore{
+		entries: make(map[string]StatusEntry),
+	}
+}
+
+func storeKey(cluster, claimRef string) string {
+	return cluster + "/" + claimRef
+}
+
+// Put inserts or updates a status entry and marks the store as dirty.
+func (s *StatusStore) Put(cluster, claimRef, status string) {
+	s.Lock()
+	defer s.Unlock()
+	s.entries[storeKey(cluster, claimRef)] = StatusEntry{
+		Cluster:       cluster,
+		ClaimRef:      claimRef,
+		StatusMessage: status,
+		ReceivedAt:    time.Now().UTC(),
+	}
+	s.dirty = true
+}
+
+// Get retrieves a status entry by cluster and claimRef.
+func (s *StatusStore) Get(cluster, claimRef string) (StatusEntry, bool) {
+	s.RLock()
+	defer s.RUnlock()
+	e, ok := s.entries[storeKey(cluster, claimRef)]
+	return e, ok
+}
+
+// GetAll returns a snapshot copy of all entries in the store.
+func (s *StatusStore) GetAll() []StatusEntry {
+	s.RLock()
+	defer s.RUnlock()
+	result := make([]StatusEntry, 0, len(s.entries))
+	for _, e := range s.entries {
+		result = append(result, e)
+	}
+	return result
+}
+
+// IsDirty reports whether the store has been modified since the last flush.
+func (s *StatusStore) IsDirty() bool {
+	s.RLock()
+	defer s.RUnlock()
+	return s.dirty
+}
+
+// MarkFlushed resets the dirty flag.
+func (s *StatusStore) MarkFlushed() {
+	s.Lock()
+	defer s.Unlock()
+	s.dirty = false
+}

--- a/internal/collector/store_test.go
+++ b/internal/collector/store_test.go
@@ -1,0 +1,102 @@
+package collector
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestPutAndGet(t *testing.T) {
+	s := NewStatusStore()
+
+	s.Put("cluster-01", "postgresqls.2.2.2/my-db", "Ready")
+
+	e, ok := s.Get("cluster-01", "postgresqls.2.2.2/my-db")
+	if !ok {
+		t.Fatal("expected entry to exist")
+	}
+	if e.Cluster != "cluster-01" {
+		t.Errorf("expected Cluster 'cluster-01', got %q", e.Cluster)
+	}
+	if e.ClaimRef != "postgresqls.2.2.2/my-db" {
+		t.Errorf("expected ClaimRef 'postgresqls.2.2.2/my-db', got %q", e.ClaimRef)
+	}
+	if e.StatusMessage != "Ready" {
+		t.Errorf("expected StatusMessage 'Ready', got %q", e.StatusMessage)
+	}
+	if e.ReceivedAt.IsZero() {
+		t.Error("expected ReceivedAt to be set")
+	}
+
+	_, ok = s.Get("cluster-01", "nonexistent")
+	if ok {
+		t.Error("expected entry to not exist")
+	}
+}
+
+func TestDirtyFlag(t *testing.T) {
+	s := NewStatusStore()
+
+	if s.IsDirty() {
+		t.Fatal("new store should not be dirty")
+	}
+
+	s.Put("cluster-01", "postgresqls.2.2.2/my-db", "Ready")
+	if !s.IsDirty() {
+		t.Fatal("store should be dirty after Put")
+	}
+
+	s.MarkFlushed()
+	if s.IsDirty() {
+		t.Fatal("store should not be dirty after MarkFlushed")
+	}
+
+	s.Put("cluster-01", "postgresqls.2.2.2/my-db", "Degraded")
+	if !s.IsDirty() {
+		t.Fatal("store should be dirty after second Put")
+	}
+}
+
+func TestConcurrentPut(t *testing.T) {
+	s := NewStatusStore()
+	var wg sync.WaitGroup
+
+	for range 100 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.Put("cluster-01", "claim/ref", "status")
+			s.Get("cluster-01", "claim/ref")
+			s.IsDirty()
+			s.GetAll()
+		}()
+	}
+
+	wg.Wait()
+
+	e, ok := s.Get("cluster-01", "claim/ref")
+	if !ok {
+		t.Fatal("expected entry to exist after concurrent writes")
+	}
+	if e.StatusMessage != "status" {
+		t.Errorf("unexpected StatusMessage: %q", e.StatusMessage)
+	}
+}
+
+func TestGetAllReturnsSnapshot(t *testing.T) {
+	s := NewStatusStore()
+	s.Put("cluster-01", "claim/a", "Ready")
+	s.Put("cluster-02", "claim/b", "Pending")
+
+	snapshot := s.GetAll()
+	if len(snapshot) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(snapshot))
+	}
+
+	// Mutating the returned slice should not affect the store.
+	snapshot[0].StatusMessage = "MODIFIED"
+
+	e, _ := s.Get(snapshot[0].Cluster, snapshot[0].ClaimRef)
+	if e.StatusMessage == "MODIFIED" {
+		t.Error("GetAll must return a copy; store was mutated via returned slice")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `StatusStore` with `sync.RWMutex` for thread-safe concurrent access in `internal/collector/store.go`
- Implement `Put`, `Get`, `GetAll`, `IsDirty`, and `MarkFlushed` methods with dirty flag tracking for reconciliation signaling
- Add tests for basic operations, dirty flag lifecycle, concurrent access (race detector), and snapshot isolation in `internal/collector/store_test.go`

Closes #8

## Test plan
- [x] `go test ./internal/collector/ -v -race` — all 4 tests pass
- [x] `go vet ./...` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)