### PR TITLE
feat: add GitHub REST API client for batch PR creation

### DIFF
--- a/internal/git/github.go
+++ b/internal/git/github.go
@@ -1,0 +1,195 @@
+package git
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// GitHubClient interacts with the GitHub REST API to manage files, branches, and pull requests.
+type GitHubClient struct {
+	token      string
+	owner      string
+	repo       string
+	httpClient *http.Client
+	baseURL    string
+}
+
+// NewGitHubClient creates a GitHubClient configured for the given repository.
+func NewGitHubClient(token, owner, repo string) *GitHubClient {
+	return &GitHubClient{
+		token:      token,
+		owner:      owner,
+		repo:       repo,
+		httpClient: &http.Client{},
+		baseURL:    "https://api.github.com",
+	}
+}
+
+// FetchFile retrieves a file's content and SHA from the given ref.
+func (c *GitHubClient) FetchFile(path, ref string) ([]byte, string, error) {
+	apiPath := fmt.Sprintf("/repos/%s/%s/contents/%s?ref=%s",
+		url.PathEscape(c.owner), url.PathEscape(c.repo), path, url.QueryEscape(ref))
+
+	resp, err := c.doRequest(http.MethodGet, apiPath, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("fetch file: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("fetch file: unexpected status %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Content  string `json:"content"`
+		SHA      string `json:"sha"`
+		Encoding string `json:"encoding"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, "", fmt.Errorf("fetch file: decode response: %w", err)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(result.Content)
+	if err != nil {
+		return nil, "", fmt.Errorf("fetch file: decode base64: %w", err)
+	}
+
+	return decoded, result.SHA, nil
+}
+
+// CreateBranch creates a new branch pointing at the given SHA.
+func (c *GitHubClient) CreateBranch(baseSHA, branchName string) error {
+	apiPath := fmt.Sprintf("/repos/%s/%s/git/refs",
+		url.PathEscape(c.owner), url.PathEscape(c.repo))
+
+	body := map[string]string{
+		"ref": "refs/heads/" + branchName,
+		"sha": baseSHA,
+	}
+
+	resp, err := c.doRequest(http.MethodPost, apiPath, body)
+	if err != nil {
+		return fmt.Errorf("create branch: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("create branch: unexpected status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+// UpdateFile commits an update to a file on the given branch.
+func (c *GitHubClient) UpdateFile(path, branchName, message string, content []byte, sha string) error {
+	apiPath := fmt.Sprintf("/repos/%s/%s/contents/%s",
+		url.PathEscape(c.owner), url.PathEscape(c.repo), path)
+
+	body := map[string]string{
+		"message": message,
+		"content": base64.StdEncoding.EncodeToString(content),
+		"sha":     sha,
+		"branch":  branchName,
+	}
+
+	resp, err := c.doRequest(http.MethodPut, apiPath, body)
+	if err != nil {
+		return fmt.Errorf("update file: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("update file: unexpected status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+// CreatePR opens a pull request and returns the PR number.
+func (c *GitHubClient) CreatePR(title, body, head, base string) (int, error) {
+	apiPath := fmt.Sprintf("/repos/%s/%s/pulls",
+		url.PathEscape(c.owner), url.PathEscape(c.repo))
+
+	reqBody := map[string]string{
+		"title": title,
+		"body":  body,
+		"head":  head,
+		"base":  base,
+	}
+
+	resp, err := c.doRequest(http.MethodPost, apiPath, reqBody)
+	if err != nil {
+		return 0, fmt.Errorf("create PR: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return 0, fmt.Errorf("create PR: unexpected status %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Number int `json:"number"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return 0, fmt.Errorf("create PR: decode response: %w", err)
+	}
+
+	return result.Number, nil
+}
+
+// ListOpenPRs returns PR numbers for open PRs from the given head branch.
+func (c *GitHubClient) ListOpenPRs(head string) ([]int, error) {
+	apiPath := fmt.Sprintf("/repos/%s/%s/pulls?state=open&head=%s:%s",
+		url.PathEscape(c.owner), url.PathEscape(c.repo),
+		url.QueryEscape(c.owner), url.QueryEscape(head))
+
+	resp, err := c.doRequest(http.MethodGet, apiPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list open PRs: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("list open PRs: unexpected status %d", resp.StatusCode)
+	}
+
+	var prs []struct {
+		Number int `json:"number"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&prs); err != nil {
+		return nil, fmt.Errorf("list open PRs: decode response: %w", err)
+	}
+
+	numbers := make([]int, len(prs))
+	for i, pr := range prs {
+		numbers[i] = pr.Number
+	}
+	return numbers, nil
+}
+
+func (c *GitHubClient) doRequest(method, path string, body any) (*http.Response, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("marshal request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequest(method, c.baseURL+path, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	return c.httpClient.Do(req)
+}

--- a/internal/git/github_test.go
+++ b/internal/git/github_test.go
@@ -1,0 +1,259 @@
+package git
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func newTestClient(url, token string) *GitHubClient {
+	return &GitHubClient{
+		token:      token,
+		owner:      "test-owner",
+		repo:       "test-repo",
+		httpClient: &http.Client{},
+		baseURL:    url,
+	}
+}
+
+func TestFetchFile(t *testing.T) {
+	want := []byte("hello world")
+	wantSHA := "abc123sha"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"content":  base64.StdEncoding.EncodeToString(want),
+			"sha":      wantSHA,
+			"encoding": "base64",
+		})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv.URL, "test-token")
+	content, sha, err := client.FetchFile("path/to/file.yaml", "main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(content) != string(want) {
+		t.Fatalf("expected content %q, got %q", want, content)
+	}
+	if sha != wantSHA {
+		t.Fatalf("expected sha %q, got %q", wantSHA, sha)
+	}
+}
+
+func TestFetchFile_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"message": "Not Found"})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv.URL, "test-token")
+	_, _, err := client.FetchFile("nonexistent.yaml", "main")
+	if err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+}
+
+func TestCreateBranch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+
+		if body["ref"] != "refs/heads/my-branch" {
+			t.Fatalf("expected ref 'refs/heads/my-branch', got %q", body["ref"])
+		}
+		if body["sha"] != "deadbeef" {
+			t.Fatalf("expected sha 'deadbeef', got %q", body["sha"])
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]string{"ref": "refs/heads/my-branch"})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv.URL, "test-token")
+	if err := client.CreateBranch("deadbeef", "my-branch"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateBranch_AlreadyExists(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		json.NewEncoder(w).Encode(map[string]string{"message": "Reference already exists"})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv.URL, "test-token")
+	if err := client.CreateBranch("deadbeef", "existing-branch"); err == nil {
+		t.Fatal("expected error for 422 response")
+	}
+}
+
+func TestUpdateFile(t *testing.T) {
+	fileContent := []byte("updated content")
+	fileSHA := "oldsha123"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Fatalf("expected PUT, got %s", r.Method)
+		}
+
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+
+		expectedContent := base64.StdEncoding.EncodeToString(fileContent)
+		if body["content"] != expectedContent {
+			t.Fatalf("expected base64 content %q, got %q", expectedContent, body["content"])
+		}
+		if body["sha"] != fileSHA {
+			t.Fatalf("expected sha %q, got %q", fileSHA, body["sha"])
+		}
+		if body["branch"] != "update-branch" {
+			t.Fatalf("expected branch 'update-branch', got %q", body["branch"])
+		}
+		if body["message"] != "update file" {
+			t.Fatalf("expected message 'update file', got %q", body["message"])
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{"content": map[string]string{"sha": "newsha456"}})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv.URL, "test-token")
+	if err := client.UpdateFile("path/to/file.yaml", "update-branch", "update file", fileContent, fileSHA); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreatePR(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+
+		if body["title"] != "Update status" {
+			t.Fatalf("expected title 'Update status', got %q", body["title"])
+		}
+		if body["body"] != "Status update PR" {
+			t.Fatalf("expected body 'Status update PR', got %q", body["body"])
+		}
+		if body["head"] != "feature-branch" {
+			t.Fatalf("expected head 'feature-branch', got %q", body["head"])
+		}
+		if body["base"] != "main" {
+			t.Fatalf("expected base 'main', got %q", body["base"])
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{"number": 42})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv.URL, "test-token")
+	num, err := client.CreatePR("Update status", "Status update PR", "feature-branch", "main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if num != 42 {
+		t.Fatalf("expected PR number 42, got %d", num)
+	}
+}
+
+func TestListOpenPRs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", r.Method)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]map[string]any{
+			{"number": 10, "title": "PR 10"},
+			{"number": 20, "title": "PR 20"},
+			{"number": 30, "title": "PR 30"},
+		})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv.URL, "test-token")
+	numbers, err := client.ListOpenPRs("my-branch")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(numbers) != 3 {
+		t.Fatalf("expected 3 PRs, got %d", len(numbers))
+	}
+	expected := []int{10, 20, 30}
+	for i, n := range numbers {
+		if n != expected[i] {
+			t.Fatalf("expected PR number %d at index %d, got %d", expected[i], i, n)
+		}
+	}
+}
+
+func TestListOpenPRs_Empty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]map[string]any{})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv.URL, "test-token")
+	numbers, err := client.ListOpenPRs("no-prs-branch")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(numbers) != 0 {
+		t.Fatalf("expected 0 PRs, got %d", len(numbers))
+	}
+}
+
+func TestAuthHeader(t *testing.T) {
+	wantToken := "my-secret-token"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer "+wantToken {
+			t.Fatalf("expected Authorization 'Bearer %s', got %q", wantToken, auth)
+		}
+
+		// Return a valid response so the method doesn't error on decode.
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"content":  base64.StdEncoding.EncodeToString([]byte("data")),
+			"sha":      "sha1",
+			"encoding": "base64",
+		})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv.URL, wantToken)
+
+	// Exercise FetchFile which uses doRequest under the hood.
+	_, _, err := client.FetchFile("any/file", "main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `GitHubClient` in `internal/git/github.go` with methods: `FetchFile`, `CreateBranch`, `UpdateFile`, `CreatePR`, `ListOpenPRs`
- Stdlib-only implementation (`net/http`, `encoding/json`, `encoding/base64`) — no new dependencies
- `baseURL` is configurable for testing with `httptest` servers

## Test plan
- [x] `TestFetchFile` — verifies base64 decoding and SHA extraction
- [x] `TestFetchFile_NotFound` — verifies error on 404
- [x] `TestCreateBranch` — verifies request body format (ref, sha)
- [x] `TestCreateBranch_AlreadyExists` — verifies error on 422
- [x] `TestUpdateFile` — verifies base64 content, sha, branch, message in request
- [x] `TestCreatePR` — verifies request body and returned PR number
- [x] `TestListOpenPRs` — verifies extracted PR numbers from response
- [x] `TestListOpenPRs_Empty` — verifies empty slice for no PRs
- [x] `TestAuthHeader` — verifies Bearer token in Authorization header
- [x] `go test ./internal/git/ -v -race` — all 9 tests pass
- [x] `go vet ./...` — clean

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)