### PR TITLE
feat: add reconciler for periodic batch PR creation

### DIFF
--- a/internal/collector/reconciler.go
+++ b/internal/collector/reconciler.go
@@ -1,0 +1,120 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/stuttgart-things/machinery-status-collector/internal/registry"
+)
+
+// GitClient abstracts the GitHub operations needed by the Reconciler.
+type GitClient interface {
+	FetchFile(path, ref string) ([]byte, string, error)
+	CreateBranch(baseSHA, branchName string) error
+	UpdateFile(path, branchName, message string, content []byte, sha string) error
+	CreatePR(title, body, head, base string) (int, error)
+	ListOpenPRs(head string) ([]int, error)
+	GetRef(branch string) (string, error)
+}
+
+// Reconciler periodically checks the status store for dirty entries and
+// opens a PR with the updated registry YAML.
+type Reconciler struct {
+	store        *StatusStore
+	gitClient    GitClient
+	interval     time.Duration
+	registryPath string
+	baseBranch   string
+}
+
+// NewReconciler creates a Reconciler that checks the store at the given interval.
+func NewReconciler(store *StatusStore, gitClient GitClient, interval time.Duration, registryPath, baseBranch string) *Reconciler {
+	return &Reconciler{
+		store:        store,
+		gitClient:    gitClient,
+		interval:     interval,
+		registryPath: registryPath,
+		baseBranch:   baseBranch,
+	}
+}
+
+// Start runs the reconciliation loop until the context is cancelled.
+func (r *Reconciler) Start(ctx context.Context) {
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := r.reconcileOnce(ctx); err != nil {
+				log.Printf("reconcile error: %v", err)
+			}
+		}
+	}
+}
+
+func (r *Reconciler) reconcileOnce(_ context.Context) error {
+	if !r.store.IsDirty() {
+		return nil
+	}
+
+	yamlBytes, fileSHA, err := r.gitClient.FetchFile(r.registryPath, r.baseBranch)
+	if err != nil {
+		return fmt.Errorf("fetch registry: %w", err)
+	}
+
+	reg, err := registry.ParseRegistry(yamlBytes)
+	if err != nil {
+		return fmt.Errorf("parse registry: %w", err)
+	}
+
+	for _, entry := range r.store.GetAll() {
+		registry.UpdateClaimStatus(reg, entry.Cluster, entry.ClaimRef, entry.StatusMessage)
+	}
+
+	updatedYAML, err := registry.SerializeRegistry(reg)
+	if err != nil {
+		return fmt.Errorf("serialize registry: %w", err)
+	}
+
+	branchName := fmt.Sprintf("status-update-%d", time.Now().Unix())
+
+	openPRs, err := r.gitClient.ListOpenPRs(branchName)
+	if err != nil {
+		return fmt.Errorf("list open PRs: %w", err)
+	}
+	if len(openPRs) > 0 {
+		return nil
+	}
+
+	commitSHA, err := r.gitClient.GetRef(r.baseBranch)
+	if err != nil {
+		return fmt.Errorf("get ref: %w", err)
+	}
+
+	if err := r.gitClient.CreateBranch(commitSHA, branchName); err != nil {
+		return fmt.Errorf("create branch: %w", err)
+	}
+
+	if err := r.gitClient.UpdateFile(r.registryPath, branchName, "chore: update claim statuses", updatedYAML, fileSHA); err != nil {
+		return fmt.Errorf("update file: %w", err)
+	}
+
+	prNum, err := r.gitClient.CreatePR(
+		"chore: update claim statuses",
+		"Automated status update from machinery-status-collector.",
+		branchName,
+		r.baseBranch,
+	)
+	if err != nil {
+		return fmt.Errorf("create PR: %w", err)
+	}
+
+	log.Printf("created PR #%d on branch %s", prNum, branchName)
+	r.store.MarkFlushed()
+	return nil
+}

--- a/internal/collector/reconciler_test.go
+++ b/internal/collector/reconciler_test.go
@@ -1,0 +1,200 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+type mockGitClient struct {
+	fetchFileContent []byte
+	fetchFileSHA     string
+	fetchFileErr     error
+
+	getRefSHA string
+	getRefErr error
+
+	createBranchErr error
+
+	updateFileErr error
+
+	createPRNumber int
+	createPRErr    error
+
+	listOpenPRsNumbers []int
+	listOpenPRsErr     error
+
+	// Track calls for assertions.
+	fetchFileCalled  bool
+	getRefCalled     bool
+	createBranchName string
+	updateFileCalled bool
+	createPRCalled   bool
+	listOpenPRsCalled bool
+}
+
+func (m *mockGitClient) FetchFile(path, ref string) ([]byte, string, error) {
+	m.fetchFileCalled = true
+	return m.fetchFileContent, m.fetchFileSHA, m.fetchFileErr
+}
+
+func (m *mockGitClient) GetRef(branch string) (string, error) {
+	m.getRefCalled = true
+	return m.getRefSHA, m.getRefErr
+}
+
+func (m *mockGitClient) CreateBranch(baseSHA, branchName string) error {
+	m.createBranchName = branchName
+	return m.createBranchErr
+}
+
+func (m *mockGitClient) UpdateFile(path, branchName, message string, content []byte, sha string) error {
+	m.updateFileCalled = true
+	return m.updateFileErr
+}
+
+func (m *mockGitClient) CreatePR(title, body, head, base string) (int, error) {
+	m.createPRCalled = true
+	return m.createPRNumber, m.createPRErr
+}
+
+func (m *mockGitClient) ListOpenPRs(head string) ([]int, error) {
+	m.listOpenPRsCalled = true
+	return m.listOpenPRsNumbers, m.listOpenPRsErr
+}
+
+const testRegistryYAML = `cluster-a:
+  - name: my-claim
+    namespace: default
+    claimRef: my-claim-ref
+    statusMessage: pending
+    lastCheckedAt: ""
+`
+
+func TestReconcileOnce_DirtyStore(t *testing.T) {
+	store := NewStatusStore()
+	store.Put("cluster-a", "my-claim-ref", "ready")
+
+	mock := &mockGitClient{
+		fetchFileContent:   []byte(testRegistryYAML),
+		fetchFileSHA:       "filesha123",
+		getRefSHA:          "commitsha456",
+		listOpenPRsNumbers: []int{},
+		createPRNumber:     7,
+	}
+
+	rec := NewReconciler(store, mock, time.Minute, "registry.yaml", "main")
+
+	if err := rec.reconcileOnce(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !mock.fetchFileCalled {
+		t.Fatal("expected FetchFile to be called")
+	}
+	if !mock.getRefCalled {
+		t.Fatal("expected GetRef to be called")
+	}
+	if mock.createBranchName == "" {
+		t.Fatal("expected CreateBranch to be called")
+	}
+	if !mock.updateFileCalled {
+		t.Fatal("expected UpdateFile to be called")
+	}
+	if !mock.createPRCalled {
+		t.Fatal("expected CreatePR to be called")
+	}
+	if store.IsDirty() {
+		t.Fatal("expected store to be flushed after successful reconcile")
+	}
+}
+
+func TestReconcileOnce_CleanStore(t *testing.T) {
+	store := NewStatusStore()
+
+	mock := &mockGitClient{}
+
+	rec := NewReconciler(store, mock, time.Minute, "registry.yaml", "main")
+
+	if err := rec.reconcileOnce(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if mock.fetchFileCalled {
+		t.Fatal("expected no git calls when store is clean")
+	}
+}
+
+func TestReconcileOnce_DuplicatePR(t *testing.T) {
+	store := NewStatusStore()
+	store.Put("cluster-a", "my-claim-ref", "ready")
+
+	mock := &mockGitClient{
+		fetchFileContent:   []byte(testRegistryYAML),
+		fetchFileSHA:       "filesha123",
+		listOpenPRsNumbers: []int{42},
+	}
+
+	rec := NewReconciler(store, mock, time.Minute, "registry.yaml", "main")
+
+	if err := rec.reconcileOnce(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !mock.listOpenPRsCalled {
+		t.Fatal("expected ListOpenPRs to be called")
+	}
+	if mock.getRefCalled {
+		t.Fatal("expected GetRef NOT to be called when duplicate PR exists")
+	}
+	if mock.createPRCalled {
+		t.Fatal("expected CreatePR NOT to be called when duplicate PR exists")
+	}
+	if !store.IsDirty() {
+		t.Fatal("expected store to remain dirty when PR creation is skipped")
+	}
+}
+
+func TestReconcileOnce_FetchFileError(t *testing.T) {
+	store := NewStatusStore()
+	store.Put("cluster-a", "my-claim-ref", "ready")
+
+	mock := &mockGitClient{
+		fetchFileErr: fmt.Errorf("network error"),
+	}
+
+	rec := NewReconciler(store, mock, time.Minute, "registry.yaml", "main")
+
+	err := rec.reconcileOnce(context.Background())
+	if err == nil {
+		t.Fatal("expected error when FetchFile fails")
+	}
+	if !store.IsDirty() {
+		t.Fatal("expected store to remain dirty after error")
+	}
+}
+
+func TestStartAndStop(t *testing.T) {
+	store := NewStatusStore()
+	mock := &mockGitClient{}
+
+	rec := NewReconciler(store, mock, 10*time.Millisecond, "registry.yaml", "main")
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		rec.Start(ctx)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("expected Start to return after context cancellation")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Reconciler` struct that periodically checks the in-memory status store for dirty entries, fetches the registry YAML from GitHub, applies status updates, and opens a PR with the changes
- Add `GitClient` interface in the collector package for testability and decoupling from the concrete GitHub client
- Add `GetRef` method to `GitHubClient` for resolving branch commit SHAs (needed to create branches via the Git refs API)
- Include comprehensive tests for all reconciler paths (dirty store, clean store, duplicate PR detection, fetch errors, graceful shutdown)

Closes #11

## Test plan
- [x] `go test ./internal/git/ -v -race` — all pass
- [x] `go test ./internal/collector/ -v -race` — all pass
- [x] `go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)