### PR TITLE
fix: change default server port from 8080 to 8095

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -52,7 +52,7 @@ func runServer(cmd *cobra.Command, args []string) error {
 	// Optional environment variables with defaults.
 	port := os.Getenv("COLLECTOR_PORT")
 	if port == "" {
-		port = "8080"
+		port = "8095"
 	}
 
 	intervalStr := os.Getenv("COLLECTOR_RECONCILE_INTERVAL")


### PR DESCRIPTION
## Summary

- Change default `COLLECTOR_PORT` from `8080` to `8095`

## Test plan

- [x] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)