### PR TITLE
feat: build and release configuration

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,29 @@
+---
+project_name: machinery-status-collector
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X github.com/stuttgart-things/machinery-status-collector/cmd.Version={{.Version}}
+      - -X github.com/stuttgart-things/machinery-status-collector/cmd.Date={{.Date}}
+      - -X github.com/stuttgart-things/machinery-status-collector/cmd.Commit={{.Commit}}
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -9,3 +9,6 @@ builds:
       - -trimpath
     ldflags:
       - -s -w
+      - -X github.com/stuttgart-things/machinery-status-collector/cmd.Version={{.Env.VERSION}}
+      - -X github.com/stuttgart-things/machinery-status-collector/cmd.Commit={{.Env.COMMIT}}
+      - -X github.com/stuttgart-things/machinery-status-collector/cmd.Date={{.Env.DATE}}

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -4,6 +4,16 @@ vars:
   PROJECT: machinery-status-collector
   MODULE: github.com/stuttgart-things/machinery-status-collector
   BIN_DIR: ./bin
+  VERSION:
+    sh: git describe --tags --always --dirty 2>/dev/null || echo "dev"
+  COMMIT:
+    sh: git rev-parse --short HEAD 2>/dev/null || echo "none"
+  DATE:
+    sh: date -u +"%Y-%m-%dT%H:%M:%SZ"
+  LDFLAGS: >-
+    -X {{.MODULE}}/cmd.Version={{.VERSION}}
+    -X {{.MODULE}}/cmd.Commit={{.COMMIT}}
+    -X {{.MODULE}}/cmd.Date={{.DATE}}
 
 includes:
   git:
@@ -14,6 +24,39 @@ includes:
     taskfile: https://raw.githubusercontent.com/stuttgart-things/tasks/refs/heads/main/go/lint.yaml
 
 tasks:
+
+  build:
+    desc: Build the binary with version info
+    cmds:
+      - go build -ldflags '{{.LDFLAGS}}' -o {{.BIN_DIR}}/{{.PROJECT}} .
+
+  test:
+    desc: Run all tests with race detection and coverage
+    cmds:
+      - go test -race -cover ./...
+
+  lint:
+    desc: Run golangci-lint
+    cmds:
+      - golangci-lint run
+
+  run-server:
+    desc: Build and run the server subcommand
+    deps: [build]
+    cmds:
+      - "{{.BIN_DIR}}/{{.PROJECT}} server"
+
+  run-informer:
+    desc: Build and run the informer subcommand
+    deps: [build]
+    cmds:
+      - "{{.BIN_DIR}}/{{.PROJECT}} informer"
+
+  tag:
+    desc: Create and push a git tag
+    cmds:
+      - git tag -a {{.CLI_ARGS}} -m "Release {{.CLI_ARGS}}"
+      - git push origin {{.CLI_ARGS}}
 
   release:dry-run:
     desc: Semantic-release Dry-Run (requires Node.js)

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -3,14 +3,18 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: machinery-status-collector
-  description: Monitor deployed claims and report health status
+  description: Collects Crossplane claim status from multiple Kubernetes clusters and reconciles updates into pull requests
   annotations:
     github.com/project-slug: stuttgart-things/machinery-status-collector
     backstage.io/techdocs-ref: dir:.
   tags:
     - golang
     - service
+  links:
+    - url: https://github.com/stuttgart-things/machinery-status-collector
+      title: Repository
+      icon: github
 spec:
   type: service
   lifecycle: experimental
-  owner: group:default/platform-team
+  owner: sthings-team


### PR DESCRIPTION
## Summary

- **Taskfile.yaml**: Add `build`, `test`, `lint`, `run-server`, `run-informer`, and `tag` tasks with ldflags for version/commit/date injection. Preserve existing `release:dry-run`, `release:trigger`, `do` tasks and remote includes.
- **.goreleaser.yaml**: New GoReleaser config for multi-platform binaries (linux/darwin, amd64/arm64) with ldflags injection and changelog generation.
- **.ko.yaml**: Add ldflags for version info injection into container images.
- **catalog-info.yaml**: Update description, add repo link, set owner to `sthings-team`.

Closes #15

## Test plan

- [x] All existing tests pass (`go test -race ./...`)
- [ ] `task build` produces a working binary with version info
- [ ] `task test` runs tests with race detection
- [ ] `goreleaser check` validates GoReleaser config
- [ ] `catalog-info.yaml` is valid Backstage YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)